### PR TITLE
Chore: Replace all existing images with placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Descubra como mais de 2.457 brasileiros estão gerando de R$1.000 até R$30.000 por mês com fontes de renda automática, trabalhando menos de 2 horas por dia." />
   <meta name="keywords" content="renda passiva, renda automática, lucro automático, renda online, ganhar dinheiro online" />
-  <link rel="icon" type="image/webp" href="/assets/images/logo.webp" />
+  <!-- Placeholder for /assets/images/logo.webp -->
+  <link rel="icon" type="image/webp" href="https://placehold.co/100x100?text=Logo" />
   <meta property="og:title" content="Guia Definitivo do Lucro Automático - 8 Fontes de Renda Passiva" />
   <meta property="og:description" content="Descubra como mais de 2.457 brasileiros estão gerando renda passiva trabalhando menos de 2 horas por dia." />
-  <meta property="og:image" content="/assets/images/logo.webp" />
+  <meta property="og:image" content="https://placehold.co/100x100?text=Logo" />
   <meta property="og:type" content="website" />
   <title>Guia Definitivo do Lucro Automático - 8 Fontes de Renda Passiva</title>
 </head>

--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -38,7 +38,8 @@ const CallToAction = () => {
 
   return (
     <section id="comprar" className="py-16 bg-black relative">
-      <div className="absolute inset-0 bg-[url('/assets/images/cta-bg.webp')] bg-cover bg-center opacity-20"></div>
+      {/* Background image placeholder for /assets/images/cta-bg.webp */}
+      <div className="absolute inset-0 bg-[url('https://placehold.co/1920x1080?text=CtaBG')] bg-cover bg-center opacity-20"></div>
       <div className="container mx-auto px-4 relative z-10">
         <div className="max-w-5xl mx-auto">
           <div className="text-center mb-12">
@@ -113,15 +114,18 @@ const CallToAction = () => {
             </h3>
             <div className="flex flex-wrap justify-center gap-4 mb-6">
               <div className="bg-white p-2 rounded flex items-center">
-                <img src="/assets/images/payment-card.webp" alt="Cartão de Crédito" className="h-8" />
+                {/* Placeholder for /assets/images/payment-card.webp */}
+                <img src="https://placehold.co/50x32?text=Card" alt="Cartão de Crédito" className="h-8" />
                 <span className="ml-2 text-sm text-gray-700 font-medium">Até 12x</span>
               </div>
               <div className="bg-white p-2 rounded flex items-center">
-                <img src="/assets/images/payment-pix.webp" alt="Pix" className="h-8" />
+                {/* Placeholder for /assets/images/payment-pix.webp */}
+                <img src="https://placehold.co/50x32?text=Pix" alt="Pix" className="h-8" />
                 <span className="ml-2 text-sm text-gray-700 font-medium">10% OFF</span>
               </div>
               <div className="bg-white p-2 rounded flex items-center">
-                <img src="/assets/images/payment-boleto.webp" alt="Boleto" className="h-8" />
+                {/* Placeholder for /assets/images/payment-boleto.webp */}
+                <img src="https://placehold.co/50x32?text=Boleto" alt="Boleto" className="h-8" />
                 <span className="ml-2 text-sm text-gray-700 font-medium">5% OFF</span>
               </div>
             </div>

--- a/src/components/Expert.jsx
+++ b/src/components/Expert.jsx
@@ -10,8 +10,9 @@ const Expert = () => {
             <div className="md:w-1/3 mb-8 md:mb-0 flex justify-center">
               <div className="relative">
                 <div className="w-48 h-48 md:w-64 md:h-64 rounded-full overflow-hidden border-4 border-green-500">
+                  {/* Placeholder for /assets/images/expert.webp */}
                   <img
-                    src="/assets/images/expert.webp"
+                    src="https://placehold.co/256x256?text=Expert"
                     alt="Ricardo Mendonça - Especialista em Renda Passiva"
                     className="w-full h-full object-cover"
                   />

--- a/src/components/FeatureCarousel.jsx
+++ b/src/components/FeatureCarousel.jsx
@@ -2,36 +2,37 @@
 import React, { useState, useEffect } from 'react';
 
 const FeatureCarousel = () => {
+  {/* Placeholders used for feature images. Original paths were /assets/images/feature-N.webp */}
   const features = [
     {
       icon: "📊",
       title: "Módulos Detalhados",
       description: "8 módulos completos com mais de 50 aulas passo a passo para implementar cada fonte de renda passiva.",
-      image: "/assets/images/feature-1.webp"
+      image: "https://placehold.co/600x400?text=Feature+1"
     },
     {
       icon: "🛠️",
       title: "Ferramentas Exclusivas",
       description: "Acesso a softwares, templates e recursos que automatizam processos e potencializam seus resultados.",
-      image: "/assets/images/feature-2.webp"
+      image: "https://placehold.co/600x400?text=Feature+2"
     },
     {
       icon: "📱",
       title: "Aplicativo Mobile",
       description: "Acesse o conteúdo de qualquer lugar, mesmo offline, através do nosso aplicativo exclusivo.",
-      image: "/assets/images/feature-3.webp"
+      image: "https://placehold.co/600x400?text=Feature+3"
     },
     {
       icon: "👥",
       title: "Comunidade VIP",
       description: "Grupo exclusivo para alunos onde você pode tirar dúvidas e fazer networking com outros empreendedores.",
-      image: "/assets/images/feature-4.webp"
+      image: "https://placehold.co/600x400?text=Feature+4"
     },
     {
       icon: "🎓",
       title: "Mentorias em Grupo",
       description: "Sessões mensais ao vivo onde respondemos dúvidas e oferecemos direcionamento estratégico.",
-      image: "/assets/images/feature-5.webp"
+      image: "https://placehold.co/600x400?text=Feature+5"
     }
   ];
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -21,8 +21,9 @@ const Header = ({ scrollPosition }) => {
     <header className={`fixed w-full z-50 transition-all duration-300 ${isScrolled ? 'bg-black bg-opacity-90 py-2' : 'bg-transparent py-4'}`}>
       <div className="container mx-auto px-4 flex justify-between items-center">
         <div className="flex items-center">
+          {/* Placeholder for /assets/images/logo.webp */}
           <img 
-            src="/assets/images/logo.webp" 
+            src="https://placehold.co/100x100?text=Logo" 
             alt="Lucro Automático Logo" 
             className="h-12 mr-2"
           />

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -5,7 +5,8 @@ import CountdownTimer from './CountdownTimer';
 const HeroSection = () => {
   return (
     <section className="pt-28 pb-20 md:pt-40 md:pb-32 relative bg-black">
-      <div className="absolute inset-0 bg-[url('/assets/images/hero-bg.webp')] bg-cover bg-center opacity-30"></div>
+      {/* Background image placeholder for /assets/images/hero-bg.webp */}
+      <div className="absolute inset-0 bg-[url('https://placehold.co/1920x1080?text=HeroBG')] bg-cover bg-center opacity-30"></div>
       <div className="container mx-auto px-4 relative z-10">
         <div className="max-w-4xl mx-auto text-center">
           <h1 className="text-3xl md:text-5xl lg:text-6xl font-bold mb-6 leading-tight">

--- a/src/components/Solution.jsx
+++ b/src/components/Solution.jsx
@@ -37,7 +37,8 @@ const Solution = () => {
 
   return (
     <section className="py-16 bg-black relative">
-      <div className="absolute inset-0 bg-[url('/assets/images/solution-bg.webp')] bg-cover bg-center opacity-20"></div>
+      {/* Background image placeholder for /assets/images/solution-bg.webp */}
+      <div className="absolute inset-0 bg-[url('https://placehold.co/1920x1080?text=SolutionBG')] bg-cover bg-center opacity-20"></div>
       <div className="container mx-auto px-4 relative z-10">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl md:text-4xl font-bold mb-4 text-center">

--- a/src/components/TestimonialCarousel.jsx
+++ b/src/components/TestimonialCarousel.jsx
@@ -2,12 +2,13 @@
 import React, { useState, useEffect } from 'react';
 
 const TestimonialCarousel = () => {
+  {/* Placeholders used for testimonial images. Original paths were /assets/images/testimonial-N.webp */}
   const testimonials = [
     {
       name: "Carlos Silva",
       location: "São Paulo, SP",
       occupation: "Ex-Gerente de Vendas",
-      image: "/assets/images/testimonial-1.webp",
+      image: "https://placehold.co/128x128?text=Person+1",
       text: "Antes do Guia Definitivo do Lucro Automático, eu trabalhava 12 horas por dia como gerente de vendas. Hoje, ganho mais do que ganhava no meu antigo emprego, trabalhando apenas 3 horas por dia com minhas lojas de dropshipping automáticas.",
       earnings: "R$ 12.500 / mês",
       source: "Dropshipping Otimizado"
@@ -16,7 +17,7 @@ const TestimonialCarousel = () => {
       name: "Mariana Costa",
       location: "Rio de Janeiro, RJ",
       occupation: "Ex-Professora",
-      image: "/assets/images/testimonial-2.webp",
+      image: "https://placehold.co/128x128?text=Person+2",
       text: "Comecei a implementar as estratégias do curso enquanto ainda dava aulas. Em 3 meses, minha renda com produtos digitais já superava meu salário como professora. Hoje tenho liberdade geográfica e de tempo para cuidar da minha família.",
       earnings: "R$ 8.700 / mês",
       source: "Produtos Digitais"
@@ -25,7 +26,7 @@ const TestimonialCarousel = () => {
       name: "Rafael Mendes",
       location: "Florianópolis, SC",
       occupation: "Estudante Universitário",
-      image: "/assets/images/testimonial-3.webp",
+      image: "https://placehold.co/128x128?text=Person+3",
       text: "Comecei a aplicar o sistema enquanto ainda estava na faculdade. Em 5 meses, já estava ganhando mais do que muitos profissionais formados. O mais incrível é que agora ganho dinheiro mesmo enquanto durmo!",
       earnings: "R$ 5.300 / mês",
       source: "Marketing de Afiliados"
@@ -34,7 +35,7 @@ const TestimonialCarousel = () => {
       name: "Juliana Ferreira",
       location: "Belo Horizonte, MG",
       occupation: "Ex-Contadora",
-      image: "/assets/images/testimonial-4.webp",
+      image: "https://placehold.co/128x128?text=Person+4",
       text: "Depois de 15 anos trabalhando como contadora, estava cansada da rotina. Com o Lucro Automático, consegui montar meu blog e canal do YouTube que hoje geram uma renda mensal maior do que eu jamais imaginei possível.",
       earnings: "R$ 15.200 / mês",
       source: "Blogs e YouTube"


### PR DESCRIPTION
I've replaced all referenced .webp images in components and index.html with placeholders from placehold.co. I also added comments next to each placeholder indicating the original image path to make it easier for you to update them later.

This change addresses your report that all current images appear broken. This will allow you to verify site functionality with placeholders and then replace them with correct, working image assets.